### PR TITLE
fix: change OG title and cover image

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -44,12 +44,12 @@ export default {
       {
         hid: 'og:url',
         property: 'og:url',
-        content: 'https://six.hackatom.org',
+        content: 'https://hackatom.org',
       },
       {
         hid: 'og:image',
         property: 'og:image',
-        content: 'https://six.hackatom.org/og-image.jpg',
+        content: 'https://hackatom.org/og-image.jpg',
       },
       // Twitter Card
       {
@@ -61,7 +61,7 @@ export default {
       {
         hid: 'twitter:title',
         name: 'twitter:title',
-        content: 'HackAtom VI 202z',
+        content: 'HackAtom VI 2021',
       },
       {
         hid: 'twitter:description',
@@ -71,7 +71,7 @@ export default {
       {
         hid: 'twitter:image',
         name: 'twitter:image',
-        content: 'https://six.hackatom.org/og-image.jpg',
+        content: 'https://hackatom.org/og-image.jpg',
       },
       {
         hid: 'twitter:image:alt',


### PR DESCRIPTION
* `og:title` to "HackAtom VI 2021"
* Fix image

Prevents this from happening:

<img width="690" alt="Screenshot 2021-11-11 at 11 01 52" src="https://user-images.githubusercontent.com/332151/141260682-73c50f39-285b-4127-b23a-953b13da0bdf.png">